### PR TITLE
Revert "SMSUsageMonitor: read limit values from Settings.Secure"

### DIFF
--- a/src/java/com/android/internal/telephony/SmsUsageMonitor.java
+++ b/src/java/com/android/internal/telephony/SmsUsageMonitor.java
@@ -273,11 +273,11 @@ public class SmsUsageMonitor {
         @Override
         public void onChange(boolean selfChange, Uri uri) {
             ContentResolver resolver = mContext.getContentResolver();
-            mMaxAllowed = Settings.Secure.getInt(resolver,
+            mMaxAllowed = Settings.Global.getInt(resolver,
                     Settings.Global.SMS_OUTGOING_CHECK_MAX_COUNT,
                     DEFAULT_SMS_MAX_COUNT);
 
-            mCheckPeriod = Settings.Secure.getInt(resolver,
+            mCheckPeriod = Settings.Global.getInt(resolver,
                     Settings.Global.SMS_OUTGOING_CHECK_INTERVAL_MS,
                     DEFAULT_SMS_CHECK_PERIOD);
         }
@@ -289,9 +289,9 @@ public class SmsUsageMonitor {
 
             ContentObserver globalObserver = new SmsLimitObserver(this, context);
 
-            resolver.registerContentObserver(Settings.Secure.getUriFor(
+            resolver.registerContentObserver(Settings.Global.getUriFor(
                     Settings.Global.SMS_OUTGOING_CHECK_MAX_COUNT), false, globalObserver);
-            resolver.registerContentObserver(Settings.Secure.getUriFor(
+            resolver.registerContentObserver(Settings.Global.getUriFor(
                     Settings.Global.SMS_OUTGOING_CHECK_INTERVAL_MS), false, globalObserver);
         }
     }


### PR DESCRIPTION
* The limit values exist only in Settings.Global

This reverts commit 64a1bac97174338d380d68e56eb286dde3a4ff8a.

Change-Id: I170a9231dd0b9c72d99f2d4d20ed55162f374d48