### PR TITLE
RIL: Fix datacall parcel reading

### DIFF
--- a/src/java/com/android/internal/telephony/RIL.java
+++ b/src/java/com/android/internal/telephony/RIL.java
@@ -3923,7 +3923,9 @@ public class RIL extends BaseCommands implements CommandsInterface {
                 if (!TextUtils.isEmpty(pcscf)) {
                     dataCall.pcscf = pcscf.split(" ");
                 }
-                dataCall.mtu = p.readInt();
+                if (version >= 11) {
+                    dataCall.mtu = p.readInt();
+                }
             }
         }
         return dataCall;


### PR DESCRIPTION
MTU is a field introduced by QC in "v11". Don't use it in older
API versions

Change-Id: Ib9f37d2b58c4e93e0223ff356071f820092faaa2