### PR TITLE
Telephony: Actually abort flex mapping if subs are null.

### DIFF
--- a/src/java/com/android/internal/telephony/ModemStackController.java
+++ b/src/java/com/android/internal/telephony/ModemStackController.java
@@ -742,6 +742,7 @@ public class ModemStackController extends Handler {
         if (subInfoList == null) {
             //if getting sub info list is failed, abort cross mapping process.
             notifyStackReady();
+            return;
         }
         for (SubscriptionInfo subInfo : subInfoList) {
             int subStatus = subCtrlr.getSubState(subInfo.getSubscriptionId());


### PR DESCRIPTION
  - Otherwise we attempt to still deactivate subscriptions
  which are not accessible.

Change-Id: I380842a3e090b0bae0cc63b4367704a89a775e43